### PR TITLE
Use 'env node' to determine where node is stored

### DIFF
--- a/bin/cozy-clis
+++ b/bin/cozy-clis
@@ -1,4 +1,4 @@
-#! /usr/local/bin/node
+#! /usr/bin/env node
 
 // Boostrap CLI tool
 var path = require('path'),


### PR DESCRIPTION
Couldn't run it locally (node isn't in /usr/local/bin on my computer). This fixes it and should be pretty general.
